### PR TITLE
Use C++11's native features in preference to Boost

### DIFF
--- a/libs/spirit/example/calc4.cpp
+++ b/libs/spirit/example/calc4.cpp
@@ -21,7 +21,6 @@
 #endif
 
 #include <boost/config/warning_disable.hpp>
-#include <boost/range/numeric.hpp>
 #include <boost/spirit/home/x3.hpp>
 #include <boost/variant/recursive_variant.hpp>
 #include <boost/variant/apply_visitor.hpp>
@@ -31,6 +30,7 @@
 #include <iostream>
 #include <string>
 #include <list>
+#include <numeric>
 
 namespace client { namespace ast
 {
@@ -169,7 +169,7 @@ namespace client { namespace ast
 
         int operator()(program const& x) const
         {
-            return boost::accumulate( x.rest
+            return std::accumulate( x.rest.begin(), x.rest.end()
                                     , boost::apply_visitor(*this, x.first)
                                     , *this);
         }

--- a/libs/spirit/example/calc4.cpp
+++ b/libs/spirit/example/calc4.cpp
@@ -252,8 +252,8 @@ main()
         ast_print print;                    // Prints the program
         ast_eval eval;                      // Evaluates the program
 
-        std::string::const_iterator iter = str.begin();
-        std::string::const_iterator end = str.end();
+        iterator_type iter = str.begin();
+        iterator_type end = str.end();
         boost::spirit::x3::ascii::space_type space;
         bool r = phrase_parse(iter, end, calc, space, program);
 

--- a/libs/spirit/example/calc4.cpp
+++ b/libs/spirit/example/calc4.cpp
@@ -25,7 +25,6 @@
 #include <boost/variant/recursive_variant.hpp>
 #include <boost/variant/apply_visitor.hpp>
 #include <boost/fusion/include/adapt_struct.hpp>
-#include <boost/foreach.hpp>
 
 #include <iostream>
 #include <string>
@@ -123,7 +122,7 @@ namespace client { namespace ast
         void operator()(program const& x) const
         {
             boost::apply_visitor(*this, x.first);
-            BOOST_FOREACH(operation const& oper, x.rest)
+            for (operation const& oper: x.rest)
             {
                 std::cout << ' ';
                 (*this)(oper);

--- a/libs/spirit/example/calc4b.cpp
+++ b/libs/spirit/example/calc4b.cpp
@@ -21,7 +21,6 @@
 #endif
 
 #include <boost/config/warning_disable.hpp>
-#include <boost/range/numeric.hpp>
 #include <boost/spirit/home/x3.hpp>
 #include <boost/variant/recursive_variant.hpp>
 #include <boost/variant/apply_visitor.hpp>
@@ -31,6 +30,7 @@
 #include <iostream>
 #include <string>
 #include <list>
+#include <numeric>
 
 namespace client { namespace ast
 {
@@ -169,7 +169,7 @@ namespace client { namespace ast
 
         int operator()(program const& x) const
         {
-            return boost::accumulate( x.rest
+            return std::accumulate( x.rest.begin(), x.rest.end()
                                     , boost::apply_visitor(*this, x.first)
                                     , *this);
         }

--- a/libs/spirit/example/calc4b.cpp
+++ b/libs/spirit/example/calc4b.cpp
@@ -25,7 +25,6 @@
 #include <boost/variant/recursive_variant.hpp>
 #include <boost/variant/apply_visitor.hpp>
 #include <boost/fusion/include/adapt_struct.hpp>
-#include <boost/foreach.hpp>
 
 #include <iostream>
 #include <string>
@@ -123,7 +122,7 @@ namespace client { namespace ast
         void operator()(program const& x) const
         {
             boost::apply_visitor(*this, x.first);
-            BOOST_FOREACH(operation const& oper, x.rest)
+            for (operation const& oper: x.rest)
             {
                 std::cout << ' ';
                 (*this)(oper);


### PR DESCRIPTION
First commit simply backports a related change from the other demo. The other two then replace BOOST_FOREACH and boost::accumulate with the C++11's native versions.
