### PR TITLE
Make sure that correct flags are passed to clang

### DIFF
--- a/libs/spirit/test/Jamfile
+++ b/libs/spirit/test/Jamfile
@@ -21,6 +21,7 @@ project spirit_x3/test
         <toolset>gcc:<cxxflags>-ftemplate-depth-512
         <toolset>darwin:<cxxflags>-std=c++0x
         <toolset>darwin:<cxxflags>-ftemplate-depth-512
+        <toolset>clang:<cxxflags>-std=c++11
     :
     :
     ;


### PR DESCRIPTION
Clang is supported on Linux as well, and shall be called with the correct
options.
