### PR TITLE
Add an explicit attribute collapsing specialization for two unused_types

### DIFF
--- a/boost/spirit/home/x3/support/traits/make_attribute.hpp
+++ b/boost/spirit/home/x3/support/traits/make_attribute.hpp
@@ -70,6 +70,17 @@ namespace boost { namespace spirit { namespace x3 { namespace traits
             return unused;
         }
     };
+
+    template <>
+    struct make_attribute<unused_type, unused_type>
+    {
+        typedef unused_type type;
+        typedef unused_type value_type;
+        static unused_type call(unused_type)
+        {
+            return unused;
+        }
+    };
 }}}}
 
 #endif

--- a/libs/spirit/test/x3/sequence.cpp
+++ b/libs/spirit/test/x3/sequence.cpp
@@ -117,6 +117,25 @@ main()
     }
 
     {
+        vector<std::string, std::string> attr;
+
+        rule<class ignored, boost::spirit::x3::unused_type> const ignored("ignored");
+        auto const ignored_def = char_('x');
+
+        rule<class rule_with_ignored, vector<std::string, std::string>> rule_with_ignored("rule_with_ignored");
+        auto const rule_with_ignored_def = +(char_ - ':') >> ":" >> *(char_ - 'x') >> ignored;
+
+        auto const unused_merging = boost::spirit::x3::grammar("unused_merging"
+                , rule_with_ignored = rule_with_ignored_def
+                , ignored = ignored_def
+                );
+
+        BOOST_TEST((test_attr("foo:barx", unused_merging, attr, true)));
+        BOOST_TEST((at_c<0>(attr) == "foo"));
+        BOOST_TEST((at_c<1>(attr) == "bar"));
+    }
+
+    {
         // a single element
         char attr;
         BOOST_TEST((test_attr("ab", char_ >> 'b', attr)));


### PR DESCRIPTION
The test case is trying to ignore the attribute of the CRLF rule. Without the
patch to make_attribute.hpp, the compiler doesn't know which of the
specializations to use, and the build fails.
