### PR TITLE
Modernize Unicode

### DIFF
--- a/include/boost/spirit/home/support/char_encoding/ascii.hpp
+++ b/include/boost/spirit/home/support/char_encoding/ascii.hpp
@@ -288,9 +288,10 @@ namespace boost { namespace spirit { namespace char_encoding
             return islower(ch) ? (ch - 'a' + 'A') : ch;
         }
 
-        static ::boost::uint32_t
+        static char32_t
         toucs4(int ch)
         {
+            BOOST_ASSERT(isascii_(ch));
             return ch;
         }
     };

--- a/include/boost/spirit/home/support/char_encoding/iso8859_1.hpp
+++ b/include/boost/spirit/home/support/char_encoding/iso8859_1.hpp
@@ -684,9 +684,10 @@ namespace boost { namespace spirit { namespace char_encoding
                 iso8859_1_char_conversion[ch] : ch;
         }
 
-        static ::boost::uint32_t
+        static char32_t
         toucs4(int ch)
         {
+            BOOST_ASSERT(0 == (ch & ~UCHAR_MAX));
             // The first 256 characters in Unicode and the UCS are
             // identical to those in ISO/IEC-8859-1.
             return ch;

--- a/include/boost/spirit/home/support/char_encoding/standard.hpp
+++ b/include/boost/spirit/home/support/char_encoding/standard.hpp
@@ -35,67 +35,67 @@ namespace boost { namespace spirit { namespace char_encoding
         {
             // uses all 8 bits
             // we have to watch out for sign extensions
-            return (0 == (ch & ~0xff) || ~0 == (ch | 0xff)) ? true : false;
+            return (0 == (ch & ~0xff) || ~0 == (ch | 0xff));
         }
 
         static bool
         isalnum(int ch)
         {
-            return std::isalnum(ch) ? true : false;
+            return std::isalnum((unsigned char)ch);
         }
 
         static bool
         isalpha(int ch)
         {
-            return std::isalpha(ch) ? true : false;
+            return std::isalpha((unsigned char)ch);
         }
 
         static bool
         isdigit(int ch)
         {
-            return std::isdigit(ch) ? true : false;
+            return std::isdigit((unsigned char)ch);
         }
 
         static bool
         isxdigit(int ch)
         {
-            return std::isxdigit(ch) ? true : false;
+            return std::isxdigit((unsigned char)ch);
         }
 
         static bool
         iscntrl(int ch)
         {
-            return std::iscntrl(ch) ? true : false;
+            return std::iscntrl((unsigned char)ch);
         }
 
         static bool
         isgraph(int ch)
         {
-            return std::isgraph(ch) ? true : false;
+            return std::isgraph((unsigned char)ch);
         }
 
         static bool
         islower(int ch)
         {
-            return std::islower(ch) ? true : false;
+            return std::islower((unsigned char)ch);
         }
 
         static bool
         isprint(int ch)
         {
-            return std::isprint(ch) ? true : false;
+            return std::isprint((unsigned char)ch);
         }
 
         static bool
         ispunct(int ch)
         {
-            return std::ispunct(ch) ? true : false;
+            return std::ispunct((unsigned char)ch);
         }
 
         static bool
         isspace(int ch)
         {
-            return std::isspace(ch) ? true : false;
+            return std::isspace((unsigned char)ch);
         }
 
         static bool
@@ -107,7 +107,7 @@ namespace boost { namespace spirit { namespace char_encoding
         static bool
         isupper(int ch)
         {
-            return std::isupper(ch) ? true : false;
+            return std::isupper((unsigned char)ch);
         }
 
     ///////////////////////////////////////////////////////////////////////////////
@@ -117,13 +117,13 @@ namespace boost { namespace spirit { namespace char_encoding
         static int
         tolower(int ch)
         {
-            return std::tolower(ch);
+            return std::tolower((unsigned char)ch);
         }
 
         static int
         toupper(int ch)
         {
-            return std::toupper(ch);
+            return std::toupper((unsigned char)ch);
         }
 
         static char32_t

--- a/include/boost/spirit/home/support/char_encoding/standard.hpp
+++ b/include/boost/spirit/home/support/char_encoding/standard.hpp
@@ -126,10 +126,10 @@ namespace boost { namespace spirit { namespace char_encoding
             return std::toupper(ch);
         }
 
-        static ::boost::uint32_t
+        static char32_t
         toucs4(int ch)
         {
-            return ch;
+            return (unsigned char)ch;
         }
     };
 }}}

--- a/include/boost/spirit/home/support/char_encoding/standard_wide.hpp
+++ b/include/boost/spirit/home/support/char_encoding/standard_wide.hpp
@@ -164,7 +164,7 @@ namespace boost { namespace spirit { namespace char_encoding
         static char32_t
         toucs4(wchar_t ch)
         {
-            return (unsigned wchar_t)ch; // in case wchar_t is 16 bits
+            return ch & traits::wchar_t_size<sizeof(wchar_t)>::mask;
         }
     };
 }}}

--- a/include/boost/spirit/home/support/char_encoding/standard_wide.hpp
+++ b/include/boost/spirit/home/support/char_encoding/standard_wide.hpp
@@ -68,84 +68,73 @@ namespace boost { namespace spirit { namespace char_encoding
                     std::size_t(ch & ~traits::wchar_t_size<sizeof(wchar_t)>::mask) || 
                 std::size_t(~0) == 
                     std::size_t(ch | traits::wchar_t_size<sizeof(wchar_t)>::mask)
-            ) ? true : false;     // any wchar_t, but no other bits set
+            ); // any wchar_t, but no other bits set
         }
 
         static bool
         isalnum(wchar_t ch)
         {
-            using namespace std;
-            return iswalnum(to_int_type(ch)) ? true : false;
+            return std::iswalnum(to_int_type(ch));
         }
 
         static bool
         isalpha(wchar_t ch)
         {
-            using namespace std;
-            return iswalpha(to_int_type(ch)) ? true : false;
+            return std::iswalpha(to_int_type(ch));
         }
 
         static bool
         iscntrl(wchar_t ch)
         {
-            using namespace std;
-            return iswcntrl(to_int_type(ch)) ? true : false;
+            return std::iswcntrl(to_int_type(ch));
         }
 
         static bool
         isdigit(wchar_t ch)
         {
-            using namespace std;
-            return iswdigit(to_int_type(ch)) ? true : false;
+            return std::iswdigit(to_int_type(ch));
         }
 
         static bool
         isgraph(wchar_t ch)
         {
-            using namespace std;
-            return iswgraph(to_int_type(ch)) ? true : false;
+            return std::iswgraph(to_int_type(ch));
         }
 
         static bool
         islower(wchar_t ch)
         {
-            using namespace std;
-            return iswlower(to_int_type(ch)) ? true : false;
+            return std::iswlower(to_int_type(ch));
         }
 
         static bool
         isprint(wchar_t ch)
         {
-            using namespace std;
-            return iswprint(to_int_type(ch)) ? true : false;
+            return std::iswprint(to_int_type(ch));
         }
 
         static bool
         ispunct(wchar_t ch)
         {
-            using namespace std;
-            return iswpunct(to_int_type(ch)) ? true : false;
+            return std::iswpunct(to_int_type(ch));
         }
 
         static bool
         isspace(wchar_t ch)
         {
-            using namespace std;
-            return iswspace(to_int_type(ch)) ? true : false;
+            return std::iswspace(to_int_type(ch));
         }
 
         static bool
         isupper(wchar_t ch)
         {
-            using namespace std;
-            return iswupper(to_int_type(ch)) ? true : false;
+            return std::iswupper(to_int_type(ch));
         }
 
         static bool
         isxdigit(wchar_t ch)
         {
-            using namespace std;
-            return iswxdigit(to_int_type(ch)) ? true : false;
+            return std::iswxdigit(to_int_type(ch));
         }
 
         static bool
@@ -161,16 +150,14 @@ namespace boost { namespace spirit { namespace char_encoding
         static wchar_t
         tolower(wchar_t ch)
         {
-            using namespace std;
-            return isupper(ch) ?
+            return std::isupper(ch) ?
                 to_char_type<wchar_t>(towlower(to_int_type(ch))) : ch;
         }
 
         static wchar_t
         toupper(wchar_t ch)
         {
-            using namespace std;
-            return islower(ch) ?
+            return std::islower(ch) ?
                 to_char_type<wchar_t>(towupper(to_int_type(ch))) : ch;
         }
 

--- a/include/boost/spirit/home/support/char_encoding/standard_wide.hpp
+++ b/include/boost/spirit/home/support/char_encoding/standard_wide.hpp
@@ -174,10 +174,10 @@ namespace boost { namespace spirit { namespace char_encoding
                 to_char_type<wchar_t>(towupper(to_int_type(ch))) : ch;
         }
 
-        static ::boost::uint32_t
-        toucs4(int ch)
+        static char32_t
+        toucs4(wchar_t ch)
         {
-            return ch;
+            return (unsigned wchar_t)ch; // in case wchar_t is 16 bits
         }
     };
 }}}

--- a/include/boost/spirit/home/support/char_encoding/standard_wide.hpp
+++ b/include/boost/spirit/home/support/char_encoding/standard_wide.hpp
@@ -62,12 +62,11 @@ namespace boost { namespace spirit { namespace char_encoding
         {
             // we have to watch out for sign extensions (casting is there to 
             // silence certain compilers complaining about signed/unsigned
-            // mismatch)
+            // mismatch); if unsigned int is not big enough then the entire API
+            // needs to stop using 'int' as a generic char-holding parameter
             return (
-                std::size_t(0) == 
-                    std::size_t(ch & ~traits::wchar_t_size<sizeof(wchar_t)>::mask) || 
-                std::size_t(~0) == 
-                    std::size_t(ch | traits::wchar_t_size<sizeof(wchar_t)>::mask)
+                 0u == unsigned(ch & ~traits::wchar_t_size<sizeof(wchar_t)>::mask) ||
+                ~0u == unsigned(ch |  traits::wchar_t_size<sizeof(wchar_t)>::mask)
             ); // any wchar_t, but no other bits set
         }
 

--- a/include/boost/spirit/home/support/char_encoding/unicode.hpp
+++ b/include/boost/spirit/home/support/char_encoding/unicode.hpp
@@ -22,7 +22,7 @@ namespace boost { namespace spirit { namespace char_encoding
     ///////////////////////////////////////////////////////////////////////////
     struct unicode
     {
-        typedef ::boost::uint32_t char_type;
+        typedef char32_t char_type;
 
     ///////////////////////////////////////////////////////////////////////////
     //  Posix stuff
@@ -34,10 +34,11 @@ namespace boost { namespace spirit { namespace char_encoding
         }
 
         static bool
-        ischar(char_type ch)
+        ischar(char_type)
         {
-            // unicode code points in the range 0x00 to 0x10FFFF
-            return ch <= 0x10FFFF;
+            // this function only checks to see if the given value can be represented, not if it's legal.
+            // unless you're planning to store code points in an array of 64-bit integers, it's all good.
+            return true;
         }
 
         static bool
@@ -128,7 +129,7 @@ namespace boost { namespace spirit { namespace char_encoding
             return ucd::to_uppercase(ch);
         }
 
-        static ::boost::uint32_t
+        static char32_t
         toucs4(char_type ch)
         {
             return ch;

--- a/include/boost/spirit/home/x3.hpp
+++ b/include/boost/spirit/home/x3.hpp
@@ -11,6 +11,12 @@
 #pragma once
 #endif
 
+#ifdef __GNUC__
+#define BOOST_SPIRIT_X3_UNUSED __attribute__((unused))
+#else
+#define BOOST_SPIRIT_X3_UNUSED
+#endif
+
 //~ #include <boost/spirit/home/x3/action.hpp>
 //~ #include <boost/spirit/home/x3/auto.hpp>
 #include <boost/spirit/home/x3/auxiliary.hpp>

--- a/include/boost/spirit/home/x3/auxiliary/attr.hpp
+++ b/include/boost/spirit/home/x3/auxiliary/attr.hpp
@@ -44,8 +44,8 @@ namespace boost { namespace spirit { namespace x3
 
         template <typename Iterator, typename Context
           , typename RuleContext, typename Attribute>
-        bool parse(Iterator& first, Iterator const& last
-          , Context const& context, RuleContext&, Attribute& attr_) const
+        bool parse(Iterator&, Iterator const&
+          , Context const&, RuleContext&, Attribute& attr_) const
         {
             // $$$ Change to copy_to once we have it $$$
             traits::move_to(value_, attr_);
@@ -80,8 +80,8 @@ namespace boost { namespace spirit { namespace x3
 
         template <typename Iterator, typename Context
           , typename RuleContext, typename Attribute>
-        bool parse(Iterator& first, Iterator const& last
-          , Context const& context, RuleContext&, Attribute& attr_) const
+        bool parse(Iterator&, Iterator const&
+          , Context const&, RuleContext&, Attribute& attr_) const
         {
             // $$$ Change to copy_to once we have it $$$
             traits::move_to(value_ + 0, value_ + N, attr_);

--- a/include/boost/spirit/home/x3/auxiliary/eps.hpp
+++ b/include/boost/spirit/home/x3/auxiliary/eps.hpp
@@ -49,7 +49,7 @@ namespace boost { namespace spirit { namespace x3
 
         template <typename Iterator, typename Context, typename Attribute>
         bool parse(Iterator& first, Iterator const& last
-          , Context const& context, unused_type, Attribute& attr) const
+          , Context const& context, unused_type, Attribute&) const
         {
             x3::skip_over(first, last, context);
             return f(x3::get<rule_context_tag>(context));

--- a/include/boost/spirit/home/x3/char/char.hpp
+++ b/include/boost/spirit/home/x3/char/char.hpp
@@ -23,19 +23,18 @@ namespace boost { namespace spirit { namespace x3
         typedef any_char<char_encoding::standard> char_type;
         char_type const char_ = char_type();
     }
-
     using standard::char_type;
     using standard::char_;
-
-    namespace standard_wide
-    {
-        typedef any_char<char_encoding::standard_wide> char_type;
-        char_type const char_ = char_type();
-    }
 
     namespace ascii
     {
         typedef any_char<char_encoding::ascii> char_type;
+        char_type const char_ = char_type();
+    }
+
+    namespace standard_wide
+    {
+        typedef any_char<char_encoding::standard_wide> char_type;
         char_type const char_ = char_type();
     }
 

--- a/include/boost/spirit/home/x3/char/unicode.hpp
+++ b/include/boost/spirit/home/x3/char/unicode.hpp
@@ -14,10 +14,66 @@
 #include <boost/spirit/home/x3/char/char_parser.hpp>
 #include <boost/spirit/home/x3/char/char.hpp>
 #include <boost/spirit/home/x3/char/detail/cast_char.hpp>
+#include <boost/spirit/home/x3/string/literal_string.hpp>
 #include <boost/spirit/home/support/char_encoding/unicode.hpp>
 
 namespace boost { namespace spirit { namespace x3
 {
+    namespace unicode
+    {
+        typedef any_char<char_encoding::unicode> char_type;
+        char_type const char_ = char_type();
+    }
+
+    namespace extension
+    {
+        template <>
+        struct as_parser<char32_t>
+        {
+            typedef literal_char<
+                char_encoding::unicode, unused_type>
+            type;
+
+            typedef type value_type;
+
+            static type call(char32_t ch)
+            {
+                return type(ch);
+            }
+        };
+
+        template <int N>
+        struct as_parser<char32_t[N]>
+        {
+            typedef
+                literal_string<
+                    char32_t const*, char_encoding::unicode, unused_type>
+            type;
+
+            typedef type value_type;
+
+            static type call(char32_t const* s)
+            {
+                return type(s);
+            }
+        };
+
+        template <int N>
+        struct as_parser<char32_t const[N]> : as_parser<char32_t[N]> {};
+    }
+
+    inline literal_char<char_encoding::unicode, unused_type>
+    lit(char32_t ch)
+    {
+        return literal_char<char_encoding::unicode, unused_type>(ch);
+    }
+
+    inline literal_string<char32_t const*, char_encoding::unicode, unused_type>
+    lit(char32_t const* s)
+    {
+        return literal_string<char32_t const*, char_encoding::unicode, unused_type>(s);
+    }
+
     ///////////////////////////////////////////////////////////////////////////
     //  Unicode Major Categories
     ///////////////////////////////////////////////////////////////////////////
@@ -430,9 +486,6 @@ namespace boost { namespace spirit { namespace x3
 
     namespace unicode
     {
-        typedef any_char<char_encoding::unicode> char_type;
-        char_type const char_ = char_type();
-
     ///////////////////////////////////////////////////////////////////////////
     //  Unicode Major Categories
     ///////////////////////////////////////////////////////////////////////////

--- a/include/boost/spirit/home/x3/core/call.hpp
+++ b/include/boost/spirit/home/x3/core/call.hpp
@@ -55,7 +55,7 @@ namespace boost { namespace spirit { namespace x3
         }
 
         template <typename F, typename Context>
-        auto call(F f, Context const& context, mpl::false_)
+        auto call(F f, Context const&, mpl::false_)
         {
             return f();
         }

--- a/include/boost/spirit/home/x3/core/detail/parse_into_container.hpp
+++ b/include/boost/spirit/home/x3/core/detail/parse_into_container.hpp
@@ -169,7 +169,7 @@ namespace boost { namespace spirit { namespace x3 { namespace detail
         static bool call(
             Parser const& parser
           , Iterator& first, Iterator const& last, Context const& context
-          , RContext& rcontext, Attribute& attr, mpl::false_)
+          , RContext& rcontext, Attribute&, mpl::false_)
         {
             return parser.parse(first, last, context, rcontext, unused);
         }

--- a/include/boost/spirit/home/x3/nonterminal/detail/rule.hpp
+++ b/include/boost/spirit/home/x3/nonterminal/detail/rule.hpp
@@ -137,7 +137,7 @@ namespace boost { namespace spirit { namespace x3 { namespace detail
     
     template <typename ID, typename RHS, typename Context>
     Context const&
-    make_rule_context(RHS const& rhs, Context const& context
+    make_rule_context(RHS const&, Context const& context
       , mpl::false_ /* is_default_parse_rule */)
     {
         return context;
@@ -155,8 +155,8 @@ namespace boost { namespace spirit { namespace x3 { namespace detail
     {
         template <typename Iterator, typename Context, typename ActualAttribute>
         static bool call_on_success(
-            Iterator& first, Iterator const& last
-          , Context const& context, ActualAttribute& attr
+            Iterator&, Iterator const&
+          , Context const&, ActualAttribute&
           , mpl::false_ /* No on_success handler */ )
         {
             return true;
@@ -284,7 +284,7 @@ namespace boost { namespace spirit { namespace x3 { namespace detail
         static bool parse_rhs(
             RHS const& rhs
           , Iterator& first, Iterator const& last
-          , Context const& context, RContext& rcontext, ActualAttribute& attr
+          , Context const& context, RContext& rcontext, ActualAttribute&
           , mpl::true_)
         {
             return parse_rhs_main(rhs, first, last, context, rcontext, unused);
@@ -294,7 +294,7 @@ namespace boost { namespace spirit { namespace x3 { namespace detail
           , typename ActualAttribute, typename ExplicitAttrPropagation>
         static bool call_rule_definition(
             RHS const& rhs
-          , char const* rule_name
+          , char const* rule_name BOOST_SPIRIT_X3_UNUSED
           , Iterator& first, Iterator const& last
           , Context const& context, ActualAttribute& attr
           , ExplicitAttrPropagation)

--- a/include/boost/spirit/home/x3/nonterminal/rule.hpp
+++ b/include/boost/spirit/home/x3/nonterminal/rule.hpp
@@ -32,7 +32,7 @@ namespace boost { namespace spirit { namespace x3
       , typename Context, typename ActualAttribute>
     inline detail::default_parse_rule_result
     parse_rule(
-        rule<ID, Attribute> rule_
+        rule<ID, Attribute>
       , Iterator& first, Iterator const& last
       , Context const& context, ActualAttribute& attr)
     {

--- a/include/boost/spirit/home/x3/operator/detail/alternative.hpp
+++ b/include/boost/spirit/home/x3/operator/detail/alternative.hpp
@@ -243,7 +243,7 @@ namespace boost { namespace spirit { namespace x3 { namespace detail
     struct move_if_not_alternative
     {
         template<typename T1, typename T2>
-        static void call(T1& attr_, T2& attr) {}
+        static void call(T1&, T2&) {}
     };
 
     template <>

--- a/include/boost/spirit/home/x3/string/literal_string.hpp
+++ b/include/boost/spirit/home/x3/string/literal_string.hpp
@@ -61,6 +61,15 @@ namespace boost { namespace spirit { namespace x3
     }
     using standard::string;
 
+    namespace standard_wide
+    {
+        inline literal_string<wchar_t const*, char_encoding::standard_wide>
+        string(wchar_t const* s)
+        {
+            return literal_string<wchar_t const*, char_encoding::standard_wide>(s);
+        }
+    }
+
     namespace extension
     {
         template <int N>
@@ -102,13 +111,18 @@ namespace boost { namespace spirit { namespace x3
         struct as_parser<wchar_t const[N]> : as_parser<wchar_t[N]> {};
     }
 
-    using standard::string;
-
     inline literal_string<char const*, char_encoding::standard, unused_type>
     lit(char const* s)
     {
         return literal_string<char const*, char_encoding::standard, unused_type>(s);
     }
+
+    inline literal_string<wchar_t const*, char_encoding::standard_wide, unused_type>
+    lit(wchar_t const* s)
+    {
+        return literal_string<wchar_t const*, char_encoding::standard_wide, unused_type>(s);
+    }
+
 
     template <typename String, typename Encoding, typename Attribute>
     struct get_info<literal_string<String, Encoding, Attribute>>

--- a/include/boost/spirit/home/x3/support/context.hpp
+++ b/include/boost/spirit/home/x3/support/context.hpp
@@ -111,7 +111,7 @@ namespace boost { namespace spirit { namespace x3
     {
         template <typename ID, typename T, typename Next, typename FoundVal>
         inline Next const&
-        make_unique_context(T& val, Next const& next, FoundVal&)
+        make_unique_context(T&, Next const& next, FoundVal&)
         {
             return next;
         }

--- a/include/boost/spirit/home/x3/support/numeric_utils/pow10.hpp
+++ b/include/boost/spirit/home/x3/support/numeric_utils/pow10.hpp
@@ -17,6 +17,7 @@
 #include <boost/limits.hpp>
 #include <boost/spirit/home/x3/support/unused.hpp>
 #include <boost/spirit/home/x3/support/traits/numeric_traits.hpp>
+#include <cfloat>
 
 #if BOOST_WORKAROUND(BOOST_MSVC, >= 1400)
 # pragma warning(push)

--- a/include/boost/spirit/home/x3/support/traits/container_traits.hpp
+++ b/include/boost/spirit/home/x3/support/traits/container_traits.hpp
@@ -152,7 +152,7 @@ namespace boost { namespace spirit { namespace x3 { namespace traits
     {
         // Not all containers have "reserve"
         template <typename Container_>
-        static void reserve(Container_& c, std::size_t size) {}
+        static void reserve(Container_&, std::size_t) {}
 
         template <typename T>
         static void reserve(std::vector<T>& c, std::size_t size)
@@ -176,7 +176,7 @@ namespace boost { namespace spirit { namespace x3 { namespace traits
     }
 
     template <typename Iterator>
-    inline bool append(unused_type, Iterator first, Iterator last)
+    inline bool append(unused_type, Iterator, Iterator)
     {
         return true;
     }

--- a/include/boost/spirit/home/x3/support/traits/print_attribute.hpp
+++ b/include/boost/spirit/home/x3/support/traits/print_attribute.hpp
@@ -73,7 +73,7 @@ namespace boost { namespace spirit { namespace x3 { namespace traits
     {
         // for plain data types
         template <typename T_>
-        static void call(Out& out, T_ const& val, unused_attribute)
+        static void call(Out& out, T_ const&, unused_attribute)
         {
             out << "unused";
         }

--- a/include/boost/spirit/home/x3/support/traits/string_traits.hpp
+++ b/include/boost/spirit/home/x3/support/traits/string_traits.hpp
@@ -34,6 +34,12 @@ namespace boost { namespace spirit { namespace x3 { namespace traits
     template <>
     struct is_char<wchar_t> : mpl::true_ {};
 
+    template <>
+    struct is_char<char16_t> : mpl::true_ {};
+
+    template <>
+    struct is_char<char32_t> : mpl::true_ {};
+
     ///////////////////////////////////////////////////////////////////////////
     // Determine if T is a string
     ///////////////////////////////////////////////////////////////////////////
@@ -41,43 +47,25 @@ namespace boost { namespace spirit { namespace x3 { namespace traits
     struct is_string : mpl::false_ {};
 
     template <typename T>
-    struct is_string<T const> : is_string<T> {};
+    struct is_string<T const> : is_char<T> {};
 
-    template <>
-    struct is_string<char const*> : mpl::true_ {};
+    template <typename T>
+    struct is_string<T*> : is_char<T> {};
 
-    template <>
-    struct is_string<wchar_t const*> : mpl::true_ {};
+    template <typename T>
+    struct is_string<T const*> : is_char<T> {};
 
-    template <>
-    struct is_string<char*> : mpl::true_ {};
+    template <typename T, std::size_t N>
+    struct is_string<T[N]> : is_char<T> {};
 
-    template <>
-    struct is_string<wchar_t*> : mpl::true_ {};
+    template <typename T, std::size_t N>
+    struct is_string<T const[N]> : is_char<T> {};
 
-    template <std::size_t N>
-    struct is_string<char[N]> : mpl::true_ {};
+    template <typename T, std::size_t N>
+    struct is_string<T(&)[N]> : is_char<T> {};
 
-    template <std::size_t N>
-    struct is_string<wchar_t[N]> : mpl::true_ {};
-
-    template <std::size_t N>
-    struct is_string<char const[N]> : mpl::true_ {};
-
-    template <std::size_t N>
-    struct is_string<wchar_t const[N]> : mpl::true_ {};
-
-    template <std::size_t N>
-    struct is_string<char(&)[N]> : mpl::true_ {};
-
-    template <std::size_t N>
-    struct is_string<wchar_t(&)[N]> : mpl::true_ {};
-
-    template <std::size_t N>
-    struct is_string<char const(&)[N]> : mpl::true_ {};
-
-    template <std::size_t N>
-    struct is_string<wchar_t const(&)[N]> : mpl::true_ {};
+    template <typename T, std::size_t N>
+    struct is_string<T const(&)[N]> : is_char<T> {};
 
     template <typename T, typename Traits, typename Allocator>
     struct is_string<std::basic_string<T, Traits, Allocator> > : mpl::true_ {};
@@ -98,40 +86,28 @@ namespace boost { namespace spirit { namespace x3 { namespace traits
     struct char_type_of<wchar_t> : mpl::identity<wchar_t> {};
 
     template <>
-    struct char_type_of<char const*> : mpl::identity<char const> {};
+    struct char_type_of<char16_t> : mpl::identity<char16_t> {};
 
     template <>
-    struct char_type_of<wchar_t const*> : mpl::identity<wchar_t const> {};
+    struct char_type_of<char32_t> : mpl::identity<char32_t> {};
 
-    template <>
-    struct char_type_of<char*> : mpl::identity<char> {};
+    template <typename T>
+    struct char_type_of<T*> : mpl::identity<typename char_type_of<T>::type> {};
 
-    template <>
-    struct char_type_of<wchar_t*> : mpl::identity<wchar_t> {};
+    template <typename T>
+    struct char_type_of<T const*> : mpl::identity<typename char_type_of<T>::type const> {};
 
-    template <std::size_t N>
-    struct char_type_of<char[N]> : mpl::identity<char> {};
+    template <typename T, std::size_t N>
+    struct char_type_of<T[N]> : mpl::identity<typename char_type_of<T>::type> {};
 
-    template <std::size_t N>
-    struct char_type_of<wchar_t[N]> : mpl::identity<wchar_t> {};
+    template <typename T, std::size_t N>
+    struct char_type_of<T const[N]> : mpl::identity<typename char_type_of<T>::type> {};
 
-    template <std::size_t N>
-    struct char_type_of<char const[N]> : mpl::identity<char const> {};
+    template <typename T, std::size_t N>
+    struct char_type_of<T(&)[N]> : mpl::identity<typename char_type_of<T>::type> {};
 
-    template <std::size_t N>
-    struct char_type_of<wchar_t const[N]> : mpl::identity<wchar_t const> {};
-
-    template <std::size_t N>
-    struct char_type_of<char(&)[N]> : mpl::identity<char> {};
-
-    template <std::size_t N>
-    struct char_type_of<wchar_t(&)[N]> : mpl::identity<wchar_t> {};
-
-    template <std::size_t N>
-    struct char_type_of<char const(&)[N]> : mpl::identity<char const> {};
-
-    template <std::size_t N>
-    struct char_type_of<wchar_t const(&)[N]> : mpl::identity<wchar_t const> {};
+    template <typename T, std::size_t N>
+    struct char_type_of<T const(&)[N]> : mpl::identity<typename char_type_of<T>::type> {};
 
     template <typename T, typename Traits, typename Allocator>
     struct char_type_of<std::basic_string<T, Traits, Allocator> >

--- a/include/boost/spirit/home/x3/support/utility/utf8.hpp
+++ b/include/boost/spirit/home/x3/support/utility/utf8.hpp
@@ -11,28 +11,24 @@
 #pragma once
 #endif
 
-#include <boost/cstdint.hpp>
-#include <boost/foreach.hpp>
+#include <cstdint>
+#include <algorithm>
+#include <type_traits>
 #include <boost/regex/pending/unicode_iterator.hpp>
-#include <boost/type_traits/make_unsigned.hpp>
 #include <string>
 
 namespace boost { namespace spirit { namespace x3
 {
-    typedef ::boost::uint32_t ucs4_char;
-    typedef char utf8_char;
-    typedef std::basic_string<ucs4_char> ucs4_string;
-    typedef std::basic_string<utf8_char> utf8_string;
+    using utf8_string = std::string;
+    using utf32_string = std::u32string;
 
     template <typename Char>
     inline utf8_string to_utf8(Char value)
     {
-        // always store as UTF8
         utf8_string result;
-        typedef std::back_insert_iterator<utf8_string> insert_iter;
-        insert_iter out_iter(result);
-        utf8_output_iterator<insert_iter> utf8_iter(out_iter);
-        typedef typename make_unsigned<Char>::type UChar;
+        using insert_iter = std::back_insert_iterator<utf8_string>;
+        utf8_output_iterator<insert_iter> utf8_iter{insert_iter(result)};
+        using UChar = typename std::make_unsigned<Char>::type;
         *utf8_iter = (UChar)value;
         return result;
     }
@@ -40,12 +36,10 @@ namespace boost { namespace spirit { namespace x3
     template <typename Char>
     inline utf8_string to_utf8(Char const* str)
     {
-        // always store as UTF8
         utf8_string result;
-        typedef std::back_insert_iterator<utf8_string> insert_iter;
-        insert_iter out_iter(result);
-        utf8_output_iterator<insert_iter> utf8_iter(out_iter);
-        typedef typename make_unsigned<Char>::type UChar;
+        using insert_iter = std::back_insert_iterator<utf8_string>;
+        utf8_output_iterator<insert_iter> utf8_iter{insert_iter(result)};
+        using UChar = typename make_unsigned<Char>::type;
         while (*str)
             *utf8_iter++ = (UChar)*str++;
         return result;
@@ -55,16 +49,13 @@ namespace boost { namespace spirit { namespace x3
     inline utf8_string
     to_utf8(std::basic_string<Char, Traits, Allocator> const& str)
     {
-        // always store as UTF8
         utf8_string result;
-        typedef std::back_insert_iterator<utf8_string> insert_iter;
-        insert_iter out_iter(result);
-        utf8_output_iterator<insert_iter> utf8_iter(out_iter);
-        typedef typename make_unsigned<Char>::type UChar;
-        BOOST_FOREACH(Char ch, str)
-        {
-            *utf8_iter++ = (UChar)ch;
-        }
+        result.reserve(str.size()); // save a few mallocs
+        using insert_iter = std::back_insert_iterator<utf8_string>;
+        utf8_output_iterator<insert_iter> utf8_iter{insert_iter(result)};
+        using UChar = typename make_unsigned<Char>::type;
+        for (UChar ch : str)
+            *utf8_iter++ = ch;
         return result;
     }
 }}}

--- a/test/x3/char1.cpp
+++ b/test/x3/char1.cpp
@@ -6,6 +6,8 @@
     file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 =============================================================================*/
 #include <boost/detail/lightweight_test.hpp>
+
+#define BOOST_SPIRIT_X3_UNICODE 1
 #include <boost/spirit/home/x3.hpp>
 
 #include <iostream>
@@ -23,6 +25,7 @@ main()
 
         BOOST_TEST(test("x", 'x'));
         BOOST_TEST(test(L"x", L'x'));
+        BOOST_TEST(test(U"x", U'x'));
         BOOST_TEST(!test("y", 'x'));
         BOOST_TEST(!test(L"y", L'x'));
 
@@ -54,6 +57,7 @@ main()
 
         BOOST_TEST(test("   x", 'x', space));
         BOOST_TEST(test(L"   x", L'x', space));
+        BOOST_TEST(test(U"   x", U'x', space));
 
         BOOST_TEST(test("   x", char_, space));
         BOOST_TEST(test("   x", char_('x'), space));
@@ -86,6 +90,33 @@ main()
         //~ BOOST_TEST(test(L"x", ~~char_(L'b', L'y')));
         //~ BOOST_TEST(!test(L"a", ~~char_(L'b', L'y')));
         //~ BOOST_TEST(!test(L"z", ~~char_(L'b', L'y')));
+    }
+
+
+    {
+        using namespace boost::spirit::x3::unicode;
+
+        BOOST_TEST(test(U"x", char_));
+        BOOST_TEST(test(U"x", char_(U'x')));
+        BOOST_TEST(!test(U"x", char_(U'y')));
+        //~ BOOST_TEST(test(U"x", char_(U'a', U'z')));
+        //~ BOOST_TEST(!test(U"x", char_(U'0', U'9')));
+
+        BOOST_TEST(!test(U"x", ~char_));
+        BOOST_TEST(!test(U"x", ~char_(U'x')));
+        BOOST_TEST(test(U" ", ~char_(U'x')));
+        BOOST_TEST(test(U"X", ~char_(U'x')));
+        //~ BOOST_TEST(!test(U"x", ~char_(U'b', U'y')));
+        //~ BOOST_TEST(test(U"a", ~char_(U'b', U'y')));
+        //~ BOOST_TEST(test(U"z", ~char_(U'b', U'y')));
+
+        BOOST_TEST(test(U"x", ~~char_));
+        BOOST_TEST(test(U"x", ~~char_(U'x')));
+        BOOST_TEST(!test(U" ", ~~char_(U'x')));
+        BOOST_TEST(!test(U"X", ~~char_(U'x')));
+        //~ BOOST_TEST(test(U"x", ~~char_(U'b', U'y')));
+        //~ BOOST_TEST(!test(U"a", ~~char_(U'b', U'y')));
+        //~ BOOST_TEST(!test(U"z", ~~char_(U'b', U'y')));
     }
 
 

--- a/test/x3/char_class.cpp
+++ b/test/x3/char_class.cpp
@@ -109,9 +109,10 @@ main()
 #if BOOST_WORKAROUND(BOOST_MSVC, BOOST_TESTED_AT(1310))
 #pragma setlocale("german")
 #endif
-        BOOST_TEST(test("é", alpha));
-        BOOST_TEST(test("é", lower));
-        BOOST_TEST(!test("é", upper));
+        const char e_acute[] = "\xE9"; // Latin-1 e with acute accent
+        BOOST_TEST(test(e_acute, alpha));
+        BOOST_TEST(test(e_acute, lower));
+        BOOST_TEST(!test(e_acute, upper));
 #if BOOST_WORKAROUND(BOOST_MSVC, BOOST_TESTED_AT(1310))
 #pragma setlocale("")
 #endif
@@ -171,43 +172,44 @@ main()
 
     {
         using namespace boost::spirit::x3::unicode;
-        BOOST_TEST(test(L"1", alnum));
-        BOOST_TEST(!test(L" ", alnum));
-        BOOST_TEST(!test(L"1", alpha));
-        BOOST_TEST(test(L"x", alpha));
-        BOOST_TEST(test(L" ", blank));
-        BOOST_TEST(!test(L"x", blank));
-        BOOST_TEST(test(L"1", digit));
-        BOOST_TEST(!test(L"x", digit));
-        BOOST_TEST(test(L"a", lower));
-        BOOST_TEST(!test(L"A", lower));
-        BOOST_TEST(test(L"!", punct));
-        BOOST_TEST(!test(L"x", punct));
-        BOOST_TEST(test(L" ", space));
-        BOOST_TEST(test(L"\n", space));
-        BOOST_TEST(test(L"\r", space));
-        BOOST_TEST(test(L"\t", space));
-        BOOST_TEST(test(L"A", upper));
-        BOOST_TEST(!test(L"a", upper));
-        BOOST_TEST(test(L"A", xdigit));
-        BOOST_TEST(test(L"0", xdigit));
-        BOOST_TEST(test(L"f", xdigit));
-        BOOST_TEST(!test(L"g", xdigit));
+        BOOST_TEST(test(U"1", alnum));
+        BOOST_TEST(!test(U" ", alnum));
+        BOOST_TEST(!test(U"1", alpha));
+        BOOST_TEST(test(U"x", alpha));
+        BOOST_TEST(test(U" ", blank));
+        BOOST_TEST(!test(U"x", blank));
+        BOOST_TEST(test(U"1", digit));
+        BOOST_TEST(!test(U"x", digit));
+        BOOST_TEST(test(U"a", lower));
+        BOOST_TEST(!test(U"A", lower));
+        BOOST_TEST(test(U"!", punct));
+        BOOST_TEST(!test(U"x", punct));
+        BOOST_TEST(test(U" ", space));
+        BOOST_TEST(test(U"\n", space));
+        BOOST_TEST(test(U"\r", space));
+        BOOST_TEST(test(U"\t", space));
+        BOOST_TEST(test(U"A", upper));
+        BOOST_TEST(!test(U"a", upper));
+        BOOST_TEST(test(U"A", xdigit));
+        BOOST_TEST(test(U"0", xdigit));
+        BOOST_TEST(test(U"f", xdigit));
+        BOOST_TEST(!test(U"g", xdigit));
 
-        BOOST_TEST(test(L"A", alphabetic));
-        BOOST_TEST(test(L"9", decimal_number));
-        BOOST_TEST(test(L"\u2800", braille));
-        BOOST_TEST(!test(L" ", braille));
-        BOOST_TEST(test(L" ", ~braille));
+        BOOST_TEST(test(U"A", alphabetic));
+        BOOST_TEST(test(U"9", decimal_number));
+        BOOST_TEST(test(U"\u2800", braille));
+        BOOST_TEST(!test(U" ", braille));
+        BOOST_TEST(test(U" ", ~braille));
         // $$$ TODO $$$ Add more unicode tests
 
 // needed for VC7.1 only
 #if BOOST_WORKAROUND(BOOST_MSVC, BOOST_TESTED_AT(1310))
 #pragma setlocale("german")
 #endif
-        BOOST_TEST(test("é", alpha));
-        BOOST_TEST(test("é", lower));
-        BOOST_TEST(!test("é", upper));
+        const char32_t e_acute[] = U"\xE9"; // Latin-1 e with acute accent
+        BOOST_TEST(test(e_acute, alpha));
+        BOOST_TEST(test(e_acute, lower));
+        BOOST_TEST(!test(e_acute, upper));
 
 #if BOOST_WORKAROUND(BOOST_MSVC, BOOST_TESTED_AT(1310))
 #pragma setlocale("")

--- a/test/x3/rule4.cpp
+++ b/test/x3/rule4.cpp
@@ -27,7 +27,7 @@ struct my_rule_class
 {
     template <typename Iterator, typename Exception, typename Context>
     x3::error_handler_result
-    on_error(Iterator&, Iterator const& last, Exception const& x, Context const& context)
+    on_error(Iterator&, Iterator const& last, Exception const& x, Context const&)
     {
         std::cout
             << "Error! Expecting: "

--- a/test/x3/tst.cpp
+++ b/test/x3/tst.cpp
@@ -89,7 +89,7 @@ namespace
     }
 }
 
-template <typename Lookup, typename WideLookup>
+template <typename Lookup, typename WideLookup, typename UnicodeLookup>
 void tests()
 {
     { // basic tests
@@ -198,6 +198,38 @@ void tests()
         docheck(lookup, L"bananaramaz", true, 6, 3);
         docheck(lookup, L"appletz", true, 5, 5);
         docheck(lookup, L"applepix", true, 5, 5);
+    }
+
+    { // utf32 tests
+        UnicodeLookup lookup;
+        add(lookup, U"pineapple", 1);
+        add(lookup, U"orange", 2);
+        add(lookup, U"banana", 3);
+        add(lookup, U"applepie", 4);
+        add(lookup, U"apple", 5);
+
+        docheck(lookup, U"pineapple", true, 9, 1);
+        docheck(lookup, U"orange", true, 6, 2);
+        docheck(lookup, U"banana", true, 6, 3);
+        docheck(lookup, U"apple", true, 5, 5);
+        docheck(lookup, U"pizza", false);
+        docheck(lookup, U"steak", false);
+        docheck(lookup, U"applepie", true, 8, 4);
+        docheck(lookup, U"bananarama", true, 6, 3);
+        docheck(lookup, U"applet", true, 5, 5);
+        docheck(lookup, U"applepi", true, 5, 5);
+        docheck(lookup, U"appl", false);
+
+        docheck(lookup, U"pineapplez", true, 9, 1);
+        docheck(lookup, U"orangez", true, 6, 2);
+        docheck(lookup, U"bananaz", true, 6, 3);
+        docheck(lookup, U"applez", true, 5, 5);
+        docheck(lookup, U"pizzaz", false);
+        docheck(lookup, U"steakz", false);
+        docheck(lookup, U"applepiez", true, 8, 4);
+        docheck(lookup, U"bananaramaz", true, 6, 3);
+        docheck(lookup, U"appletz", true, 5, 5);
+        docheck(lookup, U"applepix", true, 5, 5);
     }
 
     { // test remove
@@ -346,8 +378,8 @@ int main()
     using boost::spirit::x3::tst;
     using boost::spirit::x3::tst_map;
 
-    tests<tst<char, int>, tst<wchar_t, int> >();
-    tests<tst_map<char, int>, tst_map<wchar_t, int> >();
+    tests<tst<char, int>, tst<wchar_t, int>, tst<char32_t, int>>();
+    tests<tst_map<char, int>, tst_map<wchar_t, int>, tst_map<char32_t, int>>();
 
     return boost::report_errors();
 }

--- a/test/x3/with.cpp
+++ b/test/x3/with.cpp
@@ -16,7 +16,7 @@ struct my_rule_class
 {
     template <typename Iterator, typename Exception, typename Context>
     x3::error_handler_result
-    on_error(Iterator&, Iterator const&, Exception const& x, Context const& context)
+    on_error(Iterator&, Iterator const&, Exception const&, Context const& context)
     {
         x3::get<my_tag>(context)++;
         return x3::error_handler_result::fail;


### PR DESCRIPTION
C++11 types char16_t and char32_t are designed for overloading by Unicode encoding style; they are productively quite useful in Spirit.  So convert to using them as the fundamental types for UTF-16 and UTF-32.

Note that ischar() for 8-bit and 16-bit values just detects whether the value will fit into 8/16 bits, so I changed the one for UTF-32 to do the same; so it is always true.  As it was, you'll end up checking every character for <= 0x10FFFF before redundantly testing it for e.g. equality with 'x'.  Is this change Not Good for some reason?

Also fix high-bit characters being possibly sign-extended before being passed to std::isxxx() which is Very Bad.
Also remove names from unused parameters, so we can use -Wunused to find the really unused ones.
Also a few other minor things.
(updated to mask wchar_t properly)
